### PR TITLE
Fix error message background color

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -153,11 +153,11 @@ p {
 
 #error-message {
   display: none;
-  background-color: red;
+  background-color: #ff2d67;
   color: white;
-  padding: 2px;
-  width: 50%;
-  margin: 0 auto;
+  padding: 4px 7px;
+  width: 60%;
+  margin: 0 auto 15px auto;
   text-align: center;
   border-radius: 5px;
   -webkit-border-radius: 5px;


### PR DESCRIPTION
## Before
<img width="463" alt="Screenshot 2021-05-06 at 19 01 04" src="https://user-images.githubusercontent.com/10106044/117329548-6a36b200-ae9d-11eb-9e0f-406f7ec7d805.png">

## After

<img width="460" alt="Screenshot 2021-05-06 at 19 00 16" src="https://user-images.githubusercontent.com/10106044/117329580-73c01a00-ae9d-11eb-8b96-a870e852842f.png">

